### PR TITLE
Include warning for npm install with webpack

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,39 +2,39 @@
 
 ## General Project Setup
 
-* GitHub pull requests must require at least one review to allow merging
-* GitHub pull requests may only be merged using "merge commits" (no squash or rebase)
-* All projects should have continuous integration setup using [TravisCI]
-  * [TravisCI] must run unit tests and integration tests for every pull request
-  * [TravisCI] should run all applicable linters for every pull request
-  * GitHub pull requests must require that [TravisCI] passes to allow merging
-* All projects should have a `.gitignore` file that includes at least all build artifacts and auto-generated code (like `./build` or some generated content of `./lib`) and all dependencies (like `./node_modules`)
-* Documentation should be in markdown format
-* Sign all your git commits and tags with your private key (and add the public key to your GitHub account)
+* GitHub pull requests must require at least one review to allow merging.
+* GitHub pull requests may only be merged using "merge commits" (no squash or rebase).
+* All projects should have continuous integration setup using [TravisCI].
+  * [TravisCI] must run unit tests and integration tests for every pull request.
+  * [TravisCI] should run all applicable linters for every pull request.
+  * GitHub pull requests must require that [TravisCI] passes to allow merging.
+* All projects should have a `.gitignore` file that includes at least all build artifacts and auto-generated code (like `./build` or some generated content of `./lib`) and all dependencies (like `./node_modules`).
+* Documentation should be in markdown format.
+* Sign all your git commits and tags with your private key (and add the public key to your GitHub account).
 
 Branches:
 
-* `master` is the latest stable release
-* `develop` is the main branch and always reflects the latest development
-* `release-x.y` branches follow their respective release
+* `master` is the latest stable release.
+* `develop` is the main branch and always reflects the latest development.
+* `release-x.y` branches follow their respective release.
 
 Every project must have the following files:
 
 * `README.md`
-  * For a layout of the readme see this [readme example]
+  * For a layout of the readme see this [readme example].
   * Content should include (in this order):
-    * Title followed by relevant badges using shields.io
-    * Introductory text
-    * *Instructions* section with help on installation and usage
-    * *Related Work* section
-    * *Contributing* section with
-      * help on setup and testing
-      * a link to this guide
-      * links to [discourse] and [gitter]
+    * Title followed by relevant badges using shields.io.
+    * Introductory text.
+    * *Instructions* section with help on installation and usage.
+    * *Related Work* section.
+    * *Contributing* section with.
+      * help on setup and testing.
+      * a link to this guide.
+      * links to [discourse] and [gitter].
 * `LICENSE`
 * `CHANGELOG.md`
-  * For the layout of the changelog see this [changelog example]
-  * Notable changes should link to their pull request(s) using absolute links
+  * For the layout of the changelog see this [changelog example].
+  * Notable changes should link to their pull request(s) using absolute links.
 
 ## Releases
 
@@ -56,52 +56,55 @@ Before merging the latest changes from `develop` into a release branch:
 
 ## Solidity
 
-* Follow our [Solidity style guide]
-* Any project with Solidity code should have [ethlint] (formerly solium) installed
-  * Use this configuration: [soliumrc]
-  * Make sure all changes pass the linter before opening a pull request
-* `package.json` should include all required build steps in `scripts.prepack`
-* Provide at least the following `package.json` scripts:
-  * `test`
-  * `test:integration`
-  * `build`
-  * `lint`
+* Follow our [Solidity style guide].
+* Any project with Solidity code should have [ethlint] (formerly solium) installed.
+  * Use this configuration: [soliumrc].
+  * Make sure all changes pass the linter before opening a pull request.
 
 ### Directory Structure
 
-* All contract source code should be below the directory `./contracts`
-* All unit test and related code should be below the directory `./test`
-* All integration test and related code should be below the directory `./test_integration`
-* All build artifacts of a library project should be in the directory `./lib`
-* All documentation should be below the directory `./docs`
+* All contract source code should be below the directory `./contracts`.
+* All unit test and related code should be below the directory `./test`.
+* All integration test and related code should be below the directory `./test_integration`.
+* All build artifacts of a library project should be in the directory `./lib`.
+* All documentation should be below the directory `./docs`.
 
 ## JavaScript
 
-* Follow the [Airbnb style guide]
-* Any project with JavaScript code should have [eslint] installed
-  * Use this configuration: [eslintrc]
-  * Make sure all changes pass the linter before opening a pull request
+* Follow the [Airbnb style guide].
+* Any project with JavaScript code should have [eslint] installed.
+  * Use this configuration: [eslintrc].
+  * Make sure all changes pass the linter before opening a pull request.
 
 ### Directory Structure
 
-* All source code should be below the directory `./src`
-* All unit test and related code should be below the directory `./test`
-* All integration test and related code should be below the directory `./test_integration`
-* All build artifacts of a library project should be in the directory `./lib`
-* All documentation should be below the directory `./docs`
+* All source code should be below the directory `./src`.
+* All unit test and related code should be below the directory `./test`.
+* All integration test and related code should be below the directory `./test_integration`.
+* All build artifacts of a library project should be in the directory `./lib`.
+* All documentation should be below the directory `./docs`.
 
 ## `package.json`
 
 This section applies to Solidity and JavaScript projects alike.
 
-* `package.json` should include all required build steps in `scripts.prepack`
+* `package.json` should include all required build steps in `scripts.prepack`.
 * Provide at least the following `package.json` scripts:
   * `test`
   * `test:integration`
   * `build`
+  * `prepack`
+    * Should run all steps required before packing (publishing) the project (probably at least `npm run build`).
   * `lint`
-* Define `files` to minimize the size of the published package
-* `main` should point to `./lib/index.js`
+* Define `files` to minimize the size of the published package.
+* For library projects, `main` should point to `./lib/index.js`.
+
+### Packaged Projects
+
+⚠️ When you use a packaging tool like [webpack], make sure that `npm install` is part of the `prepack` script.
+Otherwise, packaged dependencies may be outdated.
+
+`main` (and `browser`) may point to `lib/<project>.node.js` (and `lib/<project>.web.js`).
 
 ## Rust
 
@@ -119,3 +122,4 @@ This section applies to Solidity and JavaScript projects alike.
 [solidity style guide]: ./SOLIDITY_STYLE_GUIDE.md
 [soliumrc]: ./.soliumrc.json
 [travisci]: https://travis-ci.org/
+[webpack]: https://webpack.js.org/

--- a/README.md
+++ b/README.md
@@ -95,16 +95,10 @@ This section applies to Solidity and JavaScript projects alike.
   * `build`
   * `prepack`
     * Should run all steps required before packing (publishing) the project (probably at least `npm run build`).
+    * When you use a packaging tool like [webpack], make sure that `npm ci` is part of the `prepack` script.
   * `lint`
 * Define `files` to minimize the size of the published package.
 * For library projects, `main` should point to `./lib/index.js`.
-
-### Packaged Projects
-
-⚠️ When you use a packaging tool like [webpack], make sure that `npm install` is part of the `prepack` script.
-Otherwise, packaged dependencies may be outdated.
-
-`main` (and `browser`) may point to `lib/<project>.node.js` (and `lib/<project>.web.js`).
 
 ## Rust
 


### PR DESCRIPTION
Added a new section with a warning to prevent errors like
https://github.com/OpenSTFoundation/mosaic.js/issues/133 in the future.

Smaller changes:

* Added periods to ending of sentences in bullet points.
* Deleted duplicate text on `package.json` from solidity section. The
  text is already in the section on `package.json`.