### PR TITLE
Add pull request guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,3 +157,63 @@ This section applies to Solidity and JavaScript projects alike.
 [soliumrc]: ./.soliumrc.json
 [travisci]: https://travis-ci.org/
 [webpack]: https://webpack.js.org/
+
+## Pull Requests
+
+_The following assumes that code and other work will continue to be stored on GitHub and that ZenHub will be the management tool_.
+
+A Pull Request (PR), which is a request for changing content within a repository, can be opened at anytime.
+
+Ideally, a PR is small, limited to a single objective, and in response to a specific GitHub issue.
+
+The PR is the only place any team member is expected to consult for information about the PR or its lifecycle.
+
+### Format
+
+The PR should be connected to any issues to which it is a response. If the PR resolves an issue, that should be indicated in the body of the PR (e.g., "Resolves #70", "Fixes #71", etc.).
+
+The PR's title and description should collectively address the following:
+- what is the purpose of these changes
+- what has changed
+- any information pertinent to this particular PR's review that are not generally true of PRs in the repo (e.g., assumptions, dependencies, departures from normal practice, offline agreements, etc.)
+- any additional information helpful for review (and posterity!)
+
+### Review
+
+If a PR is ready for review, the PR should be moved into the review pipeline (if it was not already there) and any assignees should be cleared.
+
+#### Assignment
+
+_The following assumes there is a single assignee for a PR. Should there be multiple assignees, apply sensible adjustments._
+
+The question of the best use of "Reviewers" and "Assignees" on GitHub appears to be open to debate. However, two features of our setup resolve the matter:
+- GitHub automatically lists anyone who adds a comment to a PR as a reviewer
+- ZenHub does not filter by reviewers, only by assignees and authors
+
+**On a PR, the person formally taking up the task of review, and who therefore accepts responsibility if she decides the work can be merged, should be set as the assignee.** This supports quick and simple assessment of resources via the ZenHub board. Others can, of course, review if they have capacity/interest and add their comments (doing so will automatically list them as reviewers), but they are not considered responsible for completion of the review.
+
+Generally speaking, the assignee self-assigns to the PR and, ideally, self-clears as necessary. If the assignee cannot complete review, that assignment should be cleared from the PR. In doing so, the PR will appear unassigned in the review pipeline on the ZenHub board and others will know that PR's review is available as a task to pick up. If the PR is not in a reviewable state, this can be reflected by moving the PR out of the review pipeline and/or assignment to the person responsible for addressing the state of the PR, according to any workflow policies or as deemed sensible.
+
+Clearing an assignment from an open PR in the review pipeline should be accompanied with an explanatory comment on the PR. When a review is completed in the normal GitHub flow (i.e., by providing a review comment with a required status such as "Request changes"), the assignment should be cleared. _For the avoidance of doubt, there is no need to add an additional comment explaining clearance of the assignment in the case of normal review completion._
+
+#### Comments
+
+Generally speaking, comments in relation to the PR (e.g. on closing, assignment, questions, change requests, etc.) should be made on the PR, and not on related issues.
+
+Generally speaking, if a comment does not concern the content or status of the PR, it should not be made on the PR. For example, a comment that the related issue was not sufficiently defined should be made on the issue, not on the PR—if the PR needs to be changed as a result of such comment, that will be reflected in changes to the PR (e.g., new or edited commits, closure, etc.).
+
+If a PR is closed but not merged, the closure should be accompanied with an explanatory comment.
+
+**Always speaking, comments should reflect empathy and respect for the author of the PR as well as the other team members.**
+
+#### Merger
+
+In addition to any other applicable PR-handling policies, **the PR should not be merged without a review completed in the normal GitHub flow from the PR's assignee.**
+
+#### Resources
+
+Some quick reads on PRs that were consulted, _inter alia_, in forming this guidance:
+- [Assigning issues and pull requests to other GitHub users](https://help.github.com/en/articles/assigning-issues-and-pull-requests-to-other-github-users)
+- [About pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews)
+- [The (written) unwritten guide to pull requests](https://www.atlassian.com/blog/git/written-unwritten-guide-pull-requests)
+- [The Art of Humanizing Pull Requests (PR’s)](https://hackernoon.com/the-art-of-humanizing-pull-requests-prs-b520588eb345)

--- a/README.md
+++ b/README.md
@@ -144,20 +144,6 @@ This section applies to Solidity and JavaScript projects alike.
 
 * Format your code using `rustfmt`.
 
-[airbnb style guide]: https://github.com/airbnb/javascript
-[changelog example]: https://github.com/OpenSTFoundation/mosaic-contracts/blob/develop/CHANGELOG.md
-[discourse]: https://discuss.openst.org/
-[eslint]: https://eslint.org/
-[eslintrc]: ./.eslintrc.json
-[ethlint]: https://github.com/duaraghav8/Ethlint
-[gitter]: https://gitter.im/OpenSTFoundation/SimpleToken
-[readme example]: https://github.com/OpenSTFoundation/mosaic.js/blob/develop/README.MD
-[semantic versioning 2]: https://semver.org/
-[solidity style guide]: ./SOLIDITY_STYLE_GUIDE.md
-[soliumrc]: ./.soliumrc.json
-[travisci]: https://travis-ci.org/
-[webpack]: https://webpack.js.org/
-
 ## Pull Requests
 
 _The following assumes that code and other work will continue to be stored on GitHub and that ZenHub will be the management tool_.
@@ -168,15 +154,24 @@ Ideally, a PR is small, limited to a single objective, and in response to a spec
 
 The PR is the only place any team member is expected to consult for information about the PR or its lifecycle.
 
+### Summary
+
+* a PR is its source of truth
+* a PR should be connected to the relevant issue(s)
+* the reviewer who takes up review formally as an item of work should self-assign on the PR
+* when the review ends, because the assignee either completes the review or will not complete the review, assignment should be cleared
+* comments on the PR should be limited to the PR
+* comments about the PR should only be made on the PR
+
 ### Format
 
 The PR should be connected to any issues to which it is a response. If the PR resolves an issue, that should be indicated in the body of the PR (e.g., "Resolves #70", "Fixes #71", etc.).
 
 The PR's title and description should collectively address the following:
-- what is the purpose of these changes
-- what has changed
-- any information pertinent to this particular PR's review that are not generally true of PRs in the repo (e.g., assumptions, dependencies, departures from normal practice, offline agreements, etc.)
-- any additional information helpful for review (and posterity!)
+* what is the purpose of these changes
+* what has changed
+* any information pertinent to this particular PR's review that are not generally true of PRs in the repo (e.g., assumptions, dependencies, departures from normal practice, offline agreements, etc.)
+* any additional information helpful for review (and posterity!)
 
 ### Review
 
@@ -187,8 +182,8 @@ If a PR is ready for review, the PR should be moved into the review pipeline (if
 _The following assumes there is a single assignee for a PR. Should there be multiple assignees, apply sensible adjustments._
 
 The question of the best use of "Reviewers" and "Assignees" on GitHub appears to be open to debate. However, two features of our setup resolve the matter:
-- GitHub automatically lists anyone who adds a comment to a PR as a reviewer
-- ZenHub does not filter by reviewers, only by assignees and authors
+* GitHub automatically lists anyone who adds a comment to a PR as a reviewer
+* ZenHub does not filter by reviewers, only by assignees and authors
 
 **On a PR, the person formally taking up the task of review, and who therefore accepts responsibility if she decides the work can be merged, should be set as the assignee.** This supports quick and simple assessment of resources via the ZenHub board. Others can, of course, review if they have capacity/interest and add their comments (doing so will automatically list them as reviewers), but they are not considered responsible for completion of the review.
 
@@ -213,7 +208,25 @@ In addition to any other applicable PR-handling policies, **the PR should not be
 #### Resources
 
 Some quick reads on PRs that were consulted, _inter alia_, in forming this guidance:
-- [Assigning issues and pull requests to other GitHub users](https://help.github.com/en/articles/assigning-issues-and-pull-requests-to-other-github-users)
-- [About pull request reviews](https://help.github.com/en/articles/about-pull-request-reviews)
-- [The (written) unwritten guide to pull requests](https://www.atlassian.com/blog/git/written-unwritten-guide-pull-requests)
-- [The Art of Humanizing Pull Requests (PR’s)](https://hackernoon.com/the-art-of-humanizing-pull-requests-prs-b520588eb345)
+* [Assigning issues and pull requests to other GitHub users]
+* [About pull request reviews]
+* [The (written) unwritten guide to pull requests]
+* [The Art of Humanizing Pull Requests (PR’s)]
+
+[airbnb style guide]: https://github.com/airbnb/javascript
+[changelog example]: https://github.com/OpenSTFoundation/mosaic-contracts/blob/develop/CHANGELOG.md
+[discourse]: https://discuss.openst.org/
+[eslint]: https://eslint.org/
+[eslintrc]: ./.eslintrc.json
+[ethlint]: https://github.com/duaraghav8/Ethlint
+[gitter]: https://gitter.im/OpenSTFoundation/SimpleToken
+[readme example]: https://github.com/OpenSTFoundation/mosaic.js/blob/develop/README.MD
+[semantic versioning 2]: https://semver.org/
+[solidity style guide]: ./SOLIDITY_STYLE_GUIDE.md
+[soliumrc]: ./.soliumrc.json
+[travisci]: https://travis-ci.org/
+[webpack]: https://webpack.js.org/
+[Assigning issues and pull requests to other GitHub users]: https://help.github.com/en/articles/assigning-issues-and-pull-requests-to-other-github-users
+[About pull request reviews]: https://help.github.com/en/articles/about-pull-request-reviews
+[The (written) unwritten guide to pull requests]: https://www.atlassian.com/blog/git/written-unwritten-guide-pull-requests
+[The Art of Humanizing Pull Requests (PR’s)]: https://hackernoon.com/the-art-of-humanizing-pull-requests-prs-b520588eb345

--- a/README.md
+++ b/README.md
@@ -154,71 +154,23 @@ Ideally, a PR is small, limited to a single objective, and in response to a spec
 
 The PR is the only place any team member is expected to consult for information about the PR or its lifecycle.
 
-### Summary
+### Attributes
 
 * a PR is its source of truth
-* a PR should be connected to the relevant issue(s)
-* the reviewer who takes up review formally as an item of work should self-assign on the PR
+* a PR should be connected using ZenHub to the relevant issue(s)
 * comments on the PR should be limited to the PR
 * comments about the PR should only be made on the PR
-* when the review ends, because the assignee either completes the review or will not complete the review, assignment should be cleared
-* at the end of a completed review, the assignee should bounce or merge the PR
 
-### Format
+### Lifecycle
 
-The PR should be connected using ZenHub to any issues to which it is a response. If the PR resolves an issue, that should be indicated in the body of the PR (e.g., "Resolves #70", "Fixes #71", etc.).
+* the reviewer who takes up review formally as an item of work should self-assign on the PR
+* when an assigned review ends, because the assignee either completes the review or will not complete the review, assignment should be cleared
+* when an assigned review completes (ends and is submitted with a required status such as "Request changes"), the assignee should (based on current GitHub options):
+  * bounce if requesting changes
+  * merge if approved
+  * communicate to the team that a second review is needed if commenting
 
-The PR's title and description should collectively address the following:
-* what is the purpose of these changes
-* what has changed
-* any information pertinent to this particular PR's review that are not generally true of PRs in the repo (e.g., assumptions, dependencies, departures from normal practice, offline agreements, etc.)
-* any additional information helpful for review (and posterity!)
-
-### Review
-
-If a PR is ready for review, the PR should be moved into the review pipeline (if it was not already there) and any assignees should be cleared.
-
-#### Assignment
-
-_The following assumes there is a single assignee for a PR. Should there be multiple assignees, apply sensible adjustments._
-
-The question of the best use of "Reviewers" and "Assignees" on GitHub appears to be open to debate. However, two features of our setup resolve the matter:
-* GitHub automatically lists anyone who adds a comment to a PR as a reviewer
-* ZenHub does not filter by reviewers, only by assignees and authors
-
-**On a PR, the person formally taking up the task of review, and who therefore accepts responsibility if she decides the work can be merged, should be set as the assignee.** This supports quick and simple assessment of resources via the ZenHub board. Others can, of course, review if they have capacity/interest and add their comments (doing so will automatically list them as reviewers), but they are not considered responsible for completion of the review.
-
-Generally speaking, the assignee self-assigns to the PR and, ideally, self-clears as necessary. If the assignee cannot complete review, that assignment should be cleared from the PR. In doing so, the PR will appear unassigned in the review pipeline on the ZenHub board and others will know that PR's review is available as a task to pick up. If the PR is not in a reviewable state, this can be reflected by moving the PR out of the review pipeline and/or assignment to the person responsible for addressing the state of the PR, according to any workflow policies or as deemed sensible.
-
-Clearing an assignment from an open PR in the review pipeline should be accompanied with an explanatory comment on the PR. When a review is completed in the normal GitHub flow (i.e., by providing a review comment with a required status such as "Request changes"), the assignment should be cleared. _For the avoidance of doubt, there is no need to add an additional comment explaining clearance of the assignment in the case of normal review completion._
-
-#### Comments
-
-Generally speaking, comments in relation to the PR (e.g. on closing, assignment, questions, change requests, etc.) should be made on the PR, and not on related issues.
-
-Generally speaking, if a comment does not concern the content or status of the PR, it should not be made on the PR. For example, a comment that the related issue was not sufficiently defined should be made on the issue, not on the PR—if the PR needs to be changed as a result of such comment, that will be reflected in changes to the PR (e.g., new or edited commits, closure, etc.).
-
-If a PR is closed but not merged, the closure should be accompanied with an explanatory comment.
-
-**Always speaking, comments should reflect empathy and respect for the author of the PR as well as the other team members.**
-
-#### Completion of a review
-
-Upon completion of a review from the PR's assignee, in the normal course, the PR should be bounced or merged.
-
-In addition to any other applicable PR-handling policies, **the PR should not be merged without a review completed in the normal GitHub flow from the PR's assignee.**
-
-#### Resources
-
-Some quick reads on PRs that were consulted, _inter alia_, in forming this guidance:
-* [Assigning issues and pull requests to other GitHub users]
-* [About pull request reviews]
-* [The (written) unwritten guide to pull requests]
-* [The Art of Humanizing Pull Requests (PR's)]
-
-[about pull request reviews]: https://help.github.com/en/articles/about-pull-request-reviews
 [airbnb style guide]: https://github.com/airbnb/javascript
-[assigning issues and pull requests to other gitHub users]: https://help.github.com/en/articles/assigning-issues-and-pull-requests-to-other-github-users
 [changelog example]: https://github.com/OpenSTFoundation/mosaic-contracts/blob/develop/CHANGELOG.md
 [discourse]: https://discuss.openst.org/
 [eslint]: https://eslint.org/
@@ -229,7 +181,5 @@ Some quick reads on PRs that were consulted, _inter alia_, in forming this guida
 [semantic versioning 2]: https://semver.org/
 [solidity style guide]: ./SOLIDITY_STYLE_GUIDE.md
 [soliumrc]: ./.soliumrc.json
-[the art of humanizing pull requests (pr's)]: https://hackernoon.com/the-art-of-humanizing-pull-requests-prs-b520588eb345
-[the (written) unwritten guide to pull requests]: https://www.atlassian.com/blog/git/written-unwritten-guide-pull-requests
 [travisci]: https://travis-ci.org/
 [webpack]: https://webpack.js.org/

--- a/README.md
+++ b/README.md
@@ -159,13 +159,14 @@ The PR is the only place any team member is expected to consult for information 
 * a PR is its source of truth
 * a PR should be connected to the relevant issue(s)
 * the reviewer who takes up review formally as an item of work should self-assign on the PR
-* when the review ends, because the assignee either completes the review or will not complete the review, assignment should be cleared
 * comments on the PR should be limited to the PR
 * comments about the PR should only be made on the PR
+* when the review ends, because the assignee either completes the review or will not complete the review, assignment should be cleared
+* at the end of a completed review, the assignee should bounce or merge the PR
 
 ### Format
 
-The PR should be connected to any issues to which it is a response. If the PR resolves an issue, that should be indicated in the body of the PR (e.g., "Resolves #70", "Fixes #71", etc.).
+The PR should be connected using ZenHub to any issues to which it is a response. If the PR resolves an issue, that should be indicated in the body of the PR (e.g., "Resolves #70", "Fixes #71", etc.).
 
 The PR's title and description should collectively address the following:
 * what is the purpose of these changes
@@ -201,7 +202,9 @@ If a PR is closed but not merged, the closure should be accompanied with an expl
 
 **Always speaking, comments should reflect empathy and respect for the author of the PR as well as the other team members.**
 
-#### Merger
+#### Completion of a review
+
+Upon completion of a review from the PR's assignee, in the normal course, the PR should be bounced or merged.
 
 In addition to any other applicable PR-handling policies, **the PR should not be merged without a review completed in the normal GitHub flow from the PR's assignee.**
 
@@ -211,9 +214,11 @@ Some quick reads on PRs that were consulted, _inter alia_, in forming this guida
 * [Assigning issues and pull requests to other GitHub users]
 * [About pull request reviews]
 * [The (written) unwritten guide to pull requests]
-* [The Art of Humanizing Pull Requests (PR’s)]
+* [The Art of Humanizing Pull Requests (PR's)]
 
+[about pull request reviews]: https://help.github.com/en/articles/about-pull-request-reviews
 [airbnb style guide]: https://github.com/airbnb/javascript
+[assigning issues and pull requests to other gitHub users]: https://help.github.com/en/articles/assigning-issues-and-pull-requests-to-other-github-users
 [changelog example]: https://github.com/OpenSTFoundation/mosaic-contracts/blob/develop/CHANGELOG.md
 [discourse]: https://discuss.openst.org/
 [eslint]: https://eslint.org/
@@ -224,9 +229,7 @@ Some quick reads on PRs that were consulted, _inter alia_, in forming this guida
 [semantic versioning 2]: https://semver.org/
 [solidity style guide]: ./SOLIDITY_STYLE_GUIDE.md
 [soliumrc]: ./.soliumrc.json
+[the art of humanizing pull requests (pr's)]: https://hackernoon.com/the-art-of-humanizing-pull-requests-prs-b520588eb345
+[the (written) unwritten guide to pull requests]: https://www.atlassian.com/blog/git/written-unwritten-guide-pull-requests
 [travisci]: https://travis-ci.org/
 [webpack]: https://webpack.js.org/
-[Assigning issues and pull requests to other GitHub users]: https://help.github.com/en/articles/assigning-issues-and-pull-requests-to-other-github-users
-[About pull request reviews]: https://help.github.com/en/articles/about-pull-request-reviews
-[The (written) unwritten guide to pull requests]: https://www.atlassian.com/blog/git/written-unwritten-guide-pull-requests
-[The Art of Humanizing Pull Requests (PR’s)]: https://hackernoon.com/the-art-of-humanizing-pull-requests-prs-b520588eb345


### PR DESCRIPTION
This PR proposes guidance on making and reviewing pull requests, as discussed internally by the team and with a view to codifying current practice.

It is wordy, but it takes a lot of words to describe a work flow and this is a fairly significant and frequent part of our flow, so maybe many words are needed 🤷‍♂️Still, there is probably fat to cut!